### PR TITLE
docs(self-hosted): scaffold deployment doc space with persona router

### DIFF
--- a/docs/self-hosted/air-gapped.mdx
+++ b/docs/self-hosted/air-gapped.mdx
@@ -1,0 +1,50 @@
+---
+title: "Air-Gapped Installation"
+description: "Deploy Plexicus to a Kubernetes cluster with no public internet access"
+---
+
+# Air-Gapped Installation \{#self-hosted_air-gapped-1}
+
+:::warning Coming soon
+A complete, step-by-step air-gapped installation guide is in preparation and will be published once the umbrella Helm chart reaches its first stable 1.x release.
+:::
+
+## What Air-Gapped Means Here \{#self-hosted_air-gapped-2}
+
+In this guide, "air-gapped" refers to any of the following deployment scenarios:
+
+- The Kubernetes cluster has **no outbound internet access** at all
+- The cluster can only reach an **internal mirror registry**, not the public Google Artifact Registry
+- Strict egress policies prevent reaching public OAuth providers, public ACME servers (Let's Encrypt), or external AI APIs
+
+The Plexicus chart is designed to support these environments — every external dependency is configurable, and every optional integration that requires public internet access can be disabled.
+
+---
+
+## What You Will Need \{#self-hosted_air-gapped-3}
+
+The full guide will cover:
+
+- Mirroring the Plexicus chart and all container images to an internal OCI registry
+- Replacing Let's Encrypt with an internal CA or pre-provisioned certificates
+- Disabling integrations that require public internet (Cloudflare Turnstile, Google OAuth, public OpenAI)
+- Bringing your own AI endpoint (e.g., self-hosted LLM, internal Azure OpenAI deployment)
+- Verifying the cluster makes zero unexpected outbound calls after install
+
+---
+
+## Early Access \{#self-hosted_air-gapped-4}
+
+If you need to deploy in an air-gapped environment before the official guide is published, contact **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)** with:
+
+- Your **organization name**
+- The **type of restriction** (no internet at all, internal mirror only, specific egress allowlist)
+- Your **certificate authority** setup (internal CA, ACME-compatible internal server, manual cert provisioning)
+
+You will receive an early-access deployment runbook tailored to your environment.
+
+---
+
+## In the Meantime \{#self-hosted_air-gapped-5}
+
+If you only need to handle a private container registry (and not full air-gap), the standard [Self-Hosted Installation](/docs/self-hosted/helm-chart) works as-is — the chart already supports custom `imagePullSecrets` and per-service `image.registry` overrides.

--- a/docs/self-hosted/configuration/index.mdx
+++ b/docs/self-hosted/configuration/index.mdx
@@ -1,0 +1,79 @@
+---
+title: "Configuration Reference"
+description: "Configure provider integrations for a self-hosted Plexicus deployment — SCM, AI, OAuth login, email, and CAPTCHA"
+---
+
+# Configuration Reference \{#self-hosted_configuration_index-1}
+
+After Plexicus is running on your cluster, you need to wire up the external provider integrations that power its features. This page is the index — per-provider walkthroughs are linked below as they are published.
+
+:::note Status
+Detailed per-provider guides are being added incrementally as the umbrella Helm chart stabilizes. Until each guide is live, the **Source of truth** column links to the canonical reference (the chart's `secrets-management.md` or the provider's own documentation), which is enough to configure a working deployment today.
+:::
+
+---
+
+## What Is Documented Here \{#self-hosted_configuration_index-2}
+
+Plexicus integrations fall into three categories. Only the first two are documented for self-hosted deployments.
+
+### ✅ Customer-facing (documented) \{#self-hosted_configuration_index-3}
+
+Integrations where **you bring your own credentials and your own external service**. Self-hosted Plexicus connects to the endpoints you specify, using the keys you provide.
+
+| Integration | Purpose | Required? | Source of truth |
+|-------------|---------|-----------|-----------------|
+| **GitHub App** | Scan GitHub repositories | Conditional — required if you scan GitHub | _coming soon_ — see [chart secrets reference](https://github.com/plexicus/platform-charts/blob/main/docs/secrets-management.md) |
+| **GitHub OAuth** | "Login with GitHub" for end users | Optional | _coming soon_ |
+| **GitLab OAuth** | Scan GitLab repositories + login | Optional | _coming soon_ |
+| **Bitbucket OAuth** | Scan Bitbucket repositories + login | Optional | _coming soon_ |
+| **Gitea OAuth** | Scan self-hosted Gitea repositories + login | Optional | _coming soon_ |
+| **Google OAuth** | "Login with Google" for end users | Optional | _coming soon_ |
+| **AI Piloting** (Azure OpenAI / OpenAI) | AI-powered remediation and enrichment | Required for AI features; degraded gracefully without | _coming soon_ |
+| **SMTP** | Email verification, invitations, password resets | **Required** | _coming soon_ |
+| **Cloudflare Turnstile** | Bot protection on public signup forms | Optional — leave empty to disable | _coming soon_ |
+| **Object storage** | Artifacts, scan reports, AI inputs/outputs | Required (bundled MinIO works out-of-the-box) | _coming soon_ |
+
+### 🟡 Chart-internal (no setup needed) \{#self-hosted_configuration_index-4}
+
+Credentials that exist purely for service-to-service communication inside your cluster. Generate a strong random value once and use the same value across the relevant Kubernetes Secrets — no external provider account is involved.
+
+| Credential | Used by | Action |
+|------------|---------|--------|
+| `PLEXALYZER_TOKEN`, `PLEXALYZER_SECRET_KEY` | Internal Plexalyzer scanning service | Generate any 32+ character random string |
+| `SECRET_KEY` (Django/FastAPI) | Session signing | Generate any 32+ character random string |
+| `NUXT_SECRET_KEY` | Frontend session signing | Generate any 32+ character random string |
+| Bundled subchart passwords (MongoDB, Redis, MinIO, Temporal PostgreSQL) | Bundled databases | Generate strong passwords; reuse across the services that connect to each |
+
+### 🔒 Plexicus-internal (intentionally not documented) \{#self-hosted_configuration_index-5}
+
+Some integrations exist in the platform code because Plexicus uses them on the **managed SaaS** offering at `plexicus.ai`. They are **not relevant to self-hosted deployments** and the chart ships with them disabled or empty by default.
+
+The following integrations will **not** be documented for self-hosted, will not appear in any guide, and should remain unset:
+
+- Stripe (Plexicus billing)
+- Cloudflare / Mautic (Plexicus marketing automation)
+- Canny (Plexicus product feedback)
+- PostHog (Plexicus product analytics)
+- Azure Application Insights (Plexicus monitoring)
+- Firebase (Plexicus push notifications)
+- Microsoft Marketplace (Plexicus listing on Azure Marketplace)
+- The `freeSastToolUrl` funnel (points to plexicus.ai)
+
+If you encounter env vars or features in the chart values that look related to any of the above, leave them empty — the chart is designed to behave correctly when these are unset.
+
+---
+
+## Where to Look in the Meantime \{#self-hosted_configuration_index-6}
+
+Until each per-provider guide is published, the canonical reference for every customer-facing environment variable lives in the chart repository:
+
+→ **[Chart `secrets-management.md`](https://github.com/plexicus/platform-charts/blob/main/docs/secrets-management.md)**
+
+That file lists every sensitive key per service, the `existingSecret` pattern used by the chart, and example `kubectl create secret` commands you can adapt directly.
+
+---
+
+## Reporting Gaps \{#self-hosted_configuration_index-7}
+
+If you discover an environment variable that is not categorized here, or a feature that requires configuration not yet covered, open an issue at [github.com/plexicus/docs](https://github.com/plexicus/docs) — those reports prioritize which per-provider guide is published next.

--- a/docs/self-hosted/helm-chart.mdx
+++ b/docs/self-hosted/helm-chart.mdx
@@ -147,12 +147,22 @@ Repeat the same pattern for `plexicus-frontend`, `plexicus-analysis-scheduler`, 
 
 ## 6. Prepare Your Values File \{#self-hosted_helm-chart-10}
 
+:::note Chart version
+The remaining commands in this guide reference a `$CHART_VERSION` shell variable. Set it once to the version you want to install — find the latest at [github.com/plexicus/platform-charts/releases](https://github.com/plexicus/platform-charts/releases):
+
+```bash
+export CHART_VERSION=1.1.0
+```
+
+This variable persists for the rest of your shell session.
+:::
+
 Pull the default values from the registry to use as a starting point:
 
 ```bash
 helm show values \
   oci://europe-west3-docker.pkg.dev/plexicus-registry/charts/plexicus \
-  --version 1.1.0 > my-values.yaml
+  --version $CHART_VERSION > my-values.yaml
 ```
 
 Open `my-values.yaml` and fill in every field marked `<to-fill>`. The sections below describe the most important ones.
@@ -247,7 +257,7 @@ The default `ingressClassName` is `traefik` and the default cert-manager cluster
 ```bash
 helm install plexicus \
   oci://europe-west3-docker.pkg.dev/plexicus-registry/charts/plexicus \
-  --version 1.1.0 \
+  --version $CHART_VERSION \
   --namespace plexicus \
   --values my-values.yaml
 ```
@@ -346,7 +356,7 @@ If you manage your cluster with ArgoCD, you can point it directly at the OCI cha
       source:
         repoURL: europe-west3-docker.pkg.dev/plexicus-registry/charts
         chart: plexicus
-        targetRevision: "1.1.0"
+        targetRevision: "1.1.0"  # replace with the latest version from the releases page
         helm:
           values: |
             global:
@@ -381,7 +391,7 @@ If you manage your cluster with ArgoCD, you can point it directly at the OCI cha
     ```
 
     :::note
-    ArgoCD ≤ 2.12 does not support semver ranges for OCI sources. Always pin `targetRevision` to an exact version string (e.g. `"1.1.0"`).
+    ArgoCD ≤ 2.12 does not support semver ranges for OCI sources. Always pin `targetRevision` to an exact version string from the [releases page](https://github.com/plexicus/platform-charts/releases) (e.g. `"1.1.0"`).
     :::
 
     Apply the manifest:

--- a/docs/self-hosted/index.mdx
+++ b/docs/self-hosted/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "Self-Hosted Overview"
+description: "Deploy Plexicus on your own Kubernetes cluster — installation paths, persona router, and the no-phone-home guarantee"
+---
+
+# Self-Hosted Plexicus \{#self-hosted_index-1}
+
+Plexicus can be deployed on any Kubernetes cluster using the official Helm chart, published as an OCI artifact to Google Artifact Registry. This section covers everything you need to install Plexicus on your own infrastructure — no support ticket required.
+
+:::tip No phone-home guarantee
+A self-hosted Plexicus deployment **does not send telemetry, analytics, or feedback data outside your cluster**. Features that depend on Plexicus' own commercial services (billing, marketplace listings, product analytics) are disabled in this mode. Only the integrations *you* configure (your GitHub, your AI provider, your SMTP server) talk to external systems — and only to the endpoints you specify.
+:::
+
+---
+
+## Choose Your Path \{#self-hosted_index-2}
+
+Pick the guide that matches what you are trying to do:
+
+### 🧪 I want to evaluate Plexicus locally \{#self-hosted_index-3}
+
+You want to spin up Plexicus on your laptop with [kind](https://kind.sigs.k8s.io/) or minikube, click around, and see if it solves your problem. You don't care about TLS, scaling, or production hardening yet.
+
+→ **[Local Evaluation (Self-Signed)](/docs/self-hosted/local-evaluation)**
+
+### 🏭 I'm deploying to a production Kubernetes cluster \{#self-hosted_index-4}
+
+You have a real cluster (GKE, EKS, AKS, on-premises, etc.), a domain you own, and you want a TLS-enabled installation that your team will use day-to-day.
+
+→ **[Self-Hosted Installation (Helm)](/docs/self-hosted/helm-chart)**
+
+### 🔒 I'm deploying to an air-gapped or restricted environment \{#self-hosted_index-5}
+
+Your cluster has no public internet access, or you need to mirror images to an internal registry, or you have strict egress controls.
+
+→ **[Air-Gapped Installation](/docs/self-hosted/air-gapped)**
+
+---
+
+## After Installation \{#self-hosted_index-6}
+
+Once the platform is running and reachable, you'll want to configure provider integrations: SCM (GitHub, GitLab, Bitbucket, Gitea), AI (OpenAI or Azure OpenAI), email (SMTP), and OAuth login providers.
+
+→ **[Configuration Reference](/docs/self-hosted/configuration)**
+
+:::note
+Per-provider configuration guides are published incrementally as the chart stabilizes. The configuration index lists which guides are available today and what is coming next.
+:::
+
+---
+
+## Getting Help \{#self-hosted_index-7}
+
+- **Documentation gaps or issues:** open an issue at [github.com/plexicus/docs](https://github.com/plexicus/docs)
+- **Chart bugs or feature requests:** [github.com/plexicus/platform-charts](https://github.com/plexicus/platform-charts)
+- **Registry access, license keys, or anything that requires a real human:** [engineering@plexicus.ai](mailto:engineering@plexicus.ai)

--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -1,0 +1,304 @@
+---
+title: "Local Evaluation (Self-Signed)"
+description: "Run Plexicus on a local Kubernetes cluster with self-signed TLS certificates for evaluation, demos, and development"
+---
+
+import {Steps, Step} from '@site/src/components/steps'
+
+# Local Evaluation \{#self-hosted_local-evaluation-1}
+
+This guide spins up Plexicus on a local Kubernetes cluster using [kind](https://kind.sigs.k8s.io/) and self-signed TLS certificates. It is intended for evaluation, demos, and development — **not production**. For production deployments, follow the [Self-Hosted Installation](/docs/self-hosted/helm-chart) guide instead.
+
+:::warning
+Self-signed certificates produce browser warnings and cannot be used by webhook integrations (GitHub, GitLab, Bitbucket) that require a publicly trusted certificate. Use this setup only for local testing.
+:::
+
+## Prerequisites \{#self-hosted_local-evaluation-2}
+
+| Requirement | Minimum version | Install command |
+|-------------|----------------|-----------------|
+| Docker | 20.10 | [Docker Desktop](https://www.docker.com/products/docker-desktop/) |
+| kind | v0.20 | `brew install kind` (macOS) |
+| Helm | v3.8 | `brew install helm` |
+| kubectl | — | `brew install kubectl` |
+
+You also need **registry access credentials** (`sa-key.json`). If you do not have them yet, request access by emailing **engineering@plexicus.ai** — see step 1 of the [Self-Hosted Installation](/docs/self-hosted/helm-chart#self-hosted_helm-chart-3) guide.
+
+---
+
+## 1. Create a Local Cluster \{#self-hosted_local-evaluation-3}
+
+Create a kind configuration file `kind-config.yaml` that exposes ports 80 and 443 to the host:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+```
+
+Create the cluster:
+
+```bash
+kind create cluster --name plexicus --config kind-config.yaml
+```
+
+Verify the cluster is running:
+
+```bash
+kubectl cluster-info --context kind-plexicus
+```
+
+---
+
+## 2. Install Ingress Controller \{#self-hosted_local-evaluation-4}
+
+Install ingress-nginx (recommended for kind):
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace \
+  --set controller.hostPort.enabled=true \
+  --set controller.service.type=NodePort
+```
+
+Wait for the controller to be ready:
+
+```bash
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=180s
+```
+
+---
+
+## 3. Install cert-manager and Self-Signed Issuer \{#self-hosted_local-evaluation-5}
+
+Install cert-manager:
+
+```bash
+helm repo add cert-manager https://charts.jetstack.io
+helm repo update
+helm upgrade --install cert-manager cert-manager/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set installCRDs=true
+```
+
+Wait for cert-manager to be ready, then apply a self-signed `ClusterIssuer`:
+
+```bash
+kubectl wait --namespace cert-manager \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/instance=cert-manager \
+  --timeout=180s
+
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+EOF
+```
+
+---
+
+## 4. Add Local DNS Entries \{#self-hosted_local-evaluation-6}
+
+Add the following lines to `/etc/hosts` (Linux/macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows):
+
+```
+127.0.0.1  plexicus.local
+127.0.0.1  api.plexicus.local
+```
+
+---
+
+## 5. Authenticate and Create Pull Secret \{#self-hosted_local-evaluation-7}
+
+Log Helm in to the OCI registry and create the namespace plus image pull secret:
+
+```bash
+cat sa-key.json | helm registry login \
+  europe-west3-docker.pkg.dev \
+  --username _json_key \
+  --password-stdin
+
+kubectl create namespace plexicus
+
+kubectl create secret docker-registry gar-secret \
+  --docker-server=europe-west3-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat sa-key.json)" \
+  --namespace plexicus
+```
+
+---
+
+## 6. Prepare a Minimal Values File \{#self-hosted_local-evaluation-8}
+
+Save the following as `values-local.yaml`. Unlike production, local evaluation can rely on the bundled MongoDB, Redis, PostgreSQL, and MinIO subcharts with shared bootstrap passwords:
+
+```yaml
+global:
+  domain: plexicus.local
+  scheme: https
+  wsScheme: wss
+  required:
+    database:
+      host: "plexicus-mongodb"
+      name: "plexicus"
+      port: 27017
+      username: "plexicus"
+      options: "authSource=admin"
+      password: "localdev-password"
+    redis:
+      host: "plexicus-redis-master"
+      port: 6379
+      password: "localdev-password"
+    minio:
+      rootUser: "plexicus"
+      rootPassword: "localdev-password"
+    postgresql:
+      password: "localdev-password"
+
+# Override the default cert-manager issuer for self-signed certs
+fastapi:
+  ingress:
+    className: "nginx"
+    annotations:
+      cert-manager.io/cluster-issuer: "selfsigned-issuer"
+    hosts:
+      - host: api.plexicus.local
+    tls:
+      - secretName: plexicus-api-tls
+        hosts:
+          - api.plexicus.local
+
+frontend:
+  ingress:
+    className: "nginx"
+    annotations:
+      cert-manager.io/cluster-issuer: "selfsigned-issuer"
+    hosts:
+      - host: plexicus.local
+    tls:
+      - secretName: plexicus-frontend-tls
+        hosts:
+          - plexicus.local
+```
+
+:::tip
+For local evaluation, application secrets (OAuth client secrets, OpenAI API key, etc.) can be omitted. Features that depend on them (e.g. SCM connectors, AI remediation) will be disabled until you provide them.
+:::
+
+---
+
+## 7. Install the Chart \{#self-hosted_local-evaluation-9}
+
+Set the chart version (find the latest at [github.com/plexicus/platform-charts/releases](https://github.com/plexicus/platform-charts/releases)):
+
+```bash
+export CHART_VERSION=1.1.0
+
+helm install plexicus \
+  oci://europe-west3-docker.pkg.dev/plexicus-registry/charts/plexicus \
+  --version $CHART_VERSION \
+  --namespace plexicus \
+  --values values-local.yaml
+```
+
+Watch the pods come up (this can take 5–10 minutes on a fresh local cluster while images are pulled):
+
+```bash
+kubectl get pods -n plexicus -w
+```
+
+---
+
+## 8. Access the Platform \{#self-hosted_local-evaluation-10}
+
+Open your browser at:
+
+**https://plexicus.local**
+
+Your browser will warn that the certificate is not trusted — this is expected with self-signed certificates. Accept the warning to continue. On Chrome, type `thisisunsafe` directly on the warning page to bypass it.
+
+---
+
+## Cleanup \{#self-hosted_local-evaluation-11}
+
+To remove the entire local environment:
+
+```bash
+kind delete cluster --name plexicus
+```
+
+To remove the entries from `/etc/hosts`, simply delete the lines you added in step 4.
+
+---
+
+## Troubleshooting \{#self-hosted_local-evaluation-12}
+
+### Pods stuck in `ImagePullBackOff` \{#self-hosted_local-evaluation-13}
+
+Verify the pull secret was created in the correct namespace and that your service account key is still valid:
+
+```bash
+kubectl get secret gar-secret -n plexicus
+kubectl describe pod <pod-name> -n plexicus | grep -A5 Events
+```
+
+### Browser cannot reach `https://plexicus.local` \{#self-hosted_local-evaluation-14}
+
+Check that the ingress controller is reachable on port 443:
+
+```bash
+curl -kv https://plexicus.local
+```
+
+If this fails, confirm the kind cluster's port mappings are active:
+
+```bash
+docker ps --filter "name=plexicus-control-plane"
+```
+
+The output should show `0.0.0.0:80->80/tcp` and `0.0.0.0:443->443/tcp`.
+
+### Certificate is not being issued \{#self-hosted_local-evaluation-15}
+
+```bash
+kubectl get certificate -n plexicus
+kubectl describe certificate plexicus-api-tls -n plexicus
+```
+
+If the certificate is stuck in `Pending`, verify the `selfsigned-issuer` `ClusterIssuer` exists and is ready:
+
+```bash
+kubectl get clusterissuer selfsigned-issuer
+```
+
+---
+
+## Next Steps \{#self-hosted_local-evaluation-16}
+
+- Once you are ready to deploy to a real cluster, follow the [Self-Hosted Installation](/docs/self-hosted/helm-chart) guide.
+- For SCM integration testing, you will need a publicly reachable cluster with valid TLS — local evaluation cannot receive webhooks from GitHub/GitLab/Bitbucket.
+- For questions or issues, contact **engineering@plexicus.ai**.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -41,8 +41,26 @@ const documentations: SidebarConfig = [
   {
     type: 'category',
     label: 'Self-Hosted',
+    link: {
+      type: 'doc',
+      id: 'self-hosted/index',
+    },
     items: [
+      'self-hosted/index',
       'self-hosted/helm-chart',
+      'self-hosted/local-evaluation',
+      'self-hosted/air-gapped',
+      {
+        type: 'category',
+        label: 'Configuration',
+        link: {
+          type: 'doc',
+          id: 'self-hosted/configuration/index',
+        },
+        items: [
+          'self-hosted/configuration/index',
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Builds out the self-hosted deployment doc space designed for three customer personas — **evaluator**, **production-operator**, **air-gapped-admin** — with a clear landing page that routes readers to the right path.

Scope is **deploy-day only** (install + first login). Per-integration configuration guides (GitHub App, OAuth providers, AI piloting, SMTP, Turnstile, etc.) are **explicitly out of scope this cycle** — the umbrella Helm chart is mid-update, so this PR prepares the structure for those guides to slot in cleanly once the chart stabilizes.

### What's in this PR

| File | Purpose |
|------|---------|
| `docs/self-hosted/index.mdx` | Landing page with 3-persona router + no-phone-home guarantee |
| `docs/self-hosted/local-evaluation.mdx` | kind + self-signed TLS guide for evaluators |
| `docs/self-hosted/air-gapped.mdx` | Stub announcing air-gapped support is coming, with early-access contact |
| `docs/self-hosted/configuration/index.mdx` | Integration matrix: customer-facing (documented) vs chart-internal vs Plexicus-internal (intentionally hidden) |
| `docs/self-hosted/helm-chart.mdx` | Refactor: externalize chart version via `$CHART_VERSION` shell variable so version bumps need a single edit |
| `sidebars.ts` | Adds nested **Configuration** subcategory under **Self-Hosted** |

### Plexicus-internal blocklist (intentionally **not** documented)

Per the configuration index, the following are flagged as managed-SaaS-only and will not appear in self-hosted guides: Stripe, Mautic, Canny, PostHog, Azure Application Insights, Firebase, Microsoft Marketplace, the `freeSastToolUrl` funnel.

### Success criterion

A customer can deploy Plexicus to k8s and reach the login page using only these docs — without emailing engineering@plexicus.ai.

## Test plan

- [ ] Verify `docs.plexicus.ai/docs/self-hosted` landing page renders with all 3 persona cards
- [ ] Confirm sidebar shows nested **Self-Hosted → Configuration** category
- [ ] Click through each persona link from the landing page — all 3 resolve
- [ ] Verify `$CHART_VERSION` shell-variable approach reads cleanly in `helm-chart.mdx` (one place to update on chart bump)
- [ ] Confirm air-gapped stub clearly says "coming soon" with contact info, not just an empty page
- [ ] Confirm configuration index lists the SaaS-only blocklist as a permanent policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)