### PR TITLE
docs(self-hosted): document prereq install model + ArgoCD prereq Applications + Apple Silicon caveat

### DIFF
--- a/docs/self-hosted/air-gapped.mdx
+++ b/docs/self-hosted/air-gapped.mdx
@@ -39,10 +39,22 @@ be disabled.
 ## High-Level Procedure \{#self-hosted_air-gapped-3}
 
 1. **Mirror all images to your internal registry.**
-   Mirror the Plexicus chart OCI artifact and all 8 custom service images — plus the 6
-   third-party subchart images (Redis, PostgreSQL, Temporal, MinIO, Elasticsearch stack,
-   MongoDB) — into an internal registry reachable from your cluster.
+   Mirror the Plexicus chart OCI artifact and the 8 custom service container images
+   (`fastapi`, `worker`, `frontend`, `analysis-scheduler`, `codex-remedium`, `exporter`,
+   `plexalyzer-code`, `plexalyzer-prov`) plus the prerequisite infrastructure images
+   (MongoDB, Redis, MinIO, PostgreSQL, Temporal — see step "Install Infrastructure
+   Prerequisites" in [the production install guide](/docs/self-hosted/helm-chart) for
+   the exact set, including any Bitnami init/sidecar images such as `os-shell`,
+   `mongodb-exporter`, `postgres-exporter`, `redis-exporter`, `redis-sentinel`,
+   `kubectl`, `minio-object-browser`).
    Full procedure: see `docs/image-registry.md` inside the chart artifact (extracted via `helm pull --untar`).
+
+   :::note Bitnami licensing change (August 2025)
+   Bitnami moved their official chart images to a paid distribution. Free legacy images
+   live under `docker.io/bitnamilegacy/*`. If you mirror these for air-gapped use, pull
+   from `bitnamilegacy/*` and re-tag into your internal registry. Production deployments
+   on amd64 Kubernetes can use these images directly.
+   :::
 
 2. **Mirror the mongo-seed-data init image separately.**
    The MongoDB seed image (`platform-standalone/mongo-seed-data`) is an init container

--- a/docs/self-hosted/configuration/index.mdx
+++ b/docs/self-hosted/configuration/index.mdx
@@ -38,7 +38,7 @@ Integrations where **you bring your own credentials and your own external servic
 | **Cloudflare Turnstile** | Bot protection on public signup forms | Optional — leave empty to disable | _coming soon_ |
 | **Object storage** | Artifacts, scan reports, AI inputs/outputs | Required (bundled MinIO works out-of-the-box) | _coming soon_ |
 | **Image registry mirror** | Mirror all custom images from your own registry — required for air-gapped or restricted networks | Optional | `docs/image-registry.md` (bundled with the chart artifact) |
-| **External dependencies (BYO Redis/Temporal/MongoDB)** | Use your own Redis, Temporal, or MongoDB instead of the bundled subcharts | Optional | See `global.dependencies` in `values-customer.yaml.example` (bundled with the chart artifact) |
+| **Infrastructure prerequisites (MongoDB, Redis, Temporal, MinIO, PostgreSQL)** | Five infra services that the Plexicus chart depends on. Install each as a separate Helm release in the same namespace before installing the umbrella chart. Customers running their own already-managed instances can skip the corresponding install and point Plexicus at the existing endpoint. | **Required** (chart 1.2.0+ no longer bundles them — bundling exceeded the 1 MB Helm release Secret limit) | `getting-started.md` and `secrets-management.md` (bundled with the chart artifact) |
 
 ### 🟡 Chart-internal (no setup needed) \{#self-hosted_configuration_index-4}
 

--- a/docs/self-hosted/helm-chart.mdx
+++ b/docs/self-hosted/helm-chart.mdx
@@ -149,7 +149,93 @@ Repeat the same pattern for `plexicus-frontend`, `plexicus-analysis-scheduler`, 
 
 ---
 
-## 6. Prepare Your Values File \{#self-hosted_helm-chart-10}
+## 6. Install Infrastructure Prerequisites \{#self-hosted_helm-chart-prereq}
+
+Plexicus depends on five infrastructure services: **MongoDB**, **Redis**, **MinIO**, **PostgreSQL**, and **Temporal**. They are **not bundled** in the umbrella chart — bundling produced an artifact that exceeded the 1 MB Kubernetes Secret limit Helm uses for release storage. Install each as a separate Helm release in the `plexicus` namespace before installing the umbrella chart. Customers who already operate any of these services can skip the corresponding install and point Plexicus at their existing endpoints via `global.required.*` and `global.dependencies.*` overrides.
+
+:::note Bitnami licensing change (August 2025)
+Bitnami moved the official chart images to a paid distribution. Free legacy images live under `docker.io/bitnamilegacy/*`. The commands below override every image reference (main + init containers + sidecars) to use the legacy registry. If you mirror these into your own registry, replace `bitnamilegacy/` with your mirror path.
+:::
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add temporal https://go.temporal.io/helm-charts
+helm repo update
+
+# 1. MongoDB
+helm upgrade --install mongodb bitnami/mongodb --version 18.6.15 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/mongodb \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/mongodb-exporter \
+  --set 'auth.rootPassword=<your-mongo-root-password>' \
+  --set 'auth.databases={plexicus}' \
+  --set 'auth.usernames={plexicus}' \
+  --set 'auth.passwords={<your-plexicus-db-password>}' \
+  --set persistence.size=10Gi --wait
+
+# 2. Redis
+helm upgrade --install redis bitnami/redis --version 25.3.2 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/redis \
+  --set sentinel.image.repository=bitnamilegacy/redis-sentinel \
+  --set metrics.image.repository=bitnamilegacy/redis-exporter \
+  --set kubectl.image.repository=bitnamilegacy/kubectl \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set sysctl.image.repository=bitnamilegacy/os-shell \
+  --set auth.password=<your-redis-password> \
+  --set replica.replicaCount=0 \
+  --set master.persistence.size=4Gi --wait
+
+# 3. MinIO
+helm upgrade --install minio bitnami/minio --version 17.0.21 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/minio \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set console.image.repository=bitnamilegacy/minio-object-browser \
+  --set apiIngress.enabled=false --set ingress.enabled=false \
+  --set auth.rootUser=<your-minio-user> \
+  --set auth.rootPassword=<your-minio-password> \
+  --set defaultBuckets=platform \
+  --set persistence.size=10Gi --wait
+
+# 4. PostgreSQL (for Temporal)
+helm upgrade --install temporal-postgresql bitnami/postgresql --version 18.5.6 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set auth.postgresPassword=<your-temporal-pg-password> \
+  --set primary.persistence.size=4Gi --wait
+
+# 5. Temporal
+helm upgrade --install temporal temporal/temporal --version 0.73.2 -n plexicus \
+  --set server.replicaCount=1 \
+  --set cassandra.enabled=false --set elasticsearch.enabled=false \
+  --set prometheus.enabled=false --set grafana.enabled=false \
+  --set server.config.persistence.default.driver=sql \
+  --set server.config.persistence.default.sql.driver=postgres12 \
+  --set server.config.persistence.default.sql.host=temporal-postgresql \
+  --set server.config.persistence.default.sql.port=5432 \
+  --set server.config.persistence.default.sql.database=temporal \
+  --set server.config.persistence.default.sql.user=postgres \
+  --set server.config.persistence.default.sql.password=<your-temporal-pg-password> \
+  --set server.config.persistence.visibility.driver=sql \
+  --set server.config.persistence.visibility.sql.driver=postgres12 \
+  --set server.config.persistence.visibility.sql.host=temporal-postgresql \
+  --set server.config.persistence.visibility.sql.port=5432 \
+  --set server.config.persistence.visibility.sql.database=temporal_visibility \
+  --set server.config.persistence.visibility.sql.user=postgres \
+  --set server.config.persistence.visibility.sql.password=<your-temporal-pg-password>
+
+kubectl -n plexicus get pods   # confirm all 5 prereqs are Running before continuing
+```
+
+The default in-cluster service names produced by these installs are `mongodb`, `redis-master`, `minio`, `temporal-postgresql`, and `temporal-frontend`. Use them as the values for `global.required.database.host`, `global.required.redis.host`, `global.required.minio.service`, and the Temporal endpoints in your customer values overlay.
+
+---
+
+## 7. Prepare Your Values File \{#self-hosted_helm-chart-10}
 
 :::note Chart version
 The remaining commands in this guide reference a `$CHART_VERSION` shell variable. Set it once to the version you want to install — your Plexicus contact will provide the current version when you receive registry credentials. To upgrade later, contact **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)** for the latest version.
@@ -419,7 +505,27 @@ If you manage your cluster with ArgoCD, you can point it directly at the OCI cha
     :::
   </Step>
 
-  <Step title="Create the ArgoCD Application">
+  <Step title="Create prerequisite Applications (sync-wave 0)">
+    Plexicus depends on five infrastructure services (MongoDB, Redis, MinIO, PostgreSQL, Temporal). They are not bundled in the umbrella chart — bundling them exceeded the 1 MB Kubernetes Secret limit Helm uses for release storage. Each is installed as its own ArgoCD Application synced before the umbrella.
+
+    Create one Application per prereq, each annotated with `argocd.argoproj.io/sync-wave: "0"`. The umbrella Application below carries `sync-wave: "5"` so ArgoCD waits for the prereqs to reach `Healthy` before it syncs.
+
+    A reference manifest set is available at `argocd/prereqs/applicationset-prereqs.yaml` inside the chart artifact (extract via `helm pull --untar`). Apply all five at once:
+
+    ```bash
+    helm pull oci://europe-west3-docker.pkg.dev/plexicus-registry/charts/plexicus \
+      --version $CHART_VERSION --untar
+    kubectl apply -f plexicus/argocd/prereqs/applicationset-prereqs.yaml
+    ```
+
+    :::note Bitnami licensing change (August 2025)
+    The reference manifest uses `bitnamilegacy/*` free legacy images. Replace `<TO-FILL>` with real passwords (or wire to ESO/Sealed-Secrets) before applying.
+    :::
+
+    Customers who already operate their own MongoDB / Redis / Temporal / MinIO / PostgreSQL can delete the corresponding Application from the manifest and instead point the umbrella Application at their existing endpoints via `global.required.*` and `global.dependencies.*` overrides.
+  </Step>
+
+  <Step title="Create the umbrella ArgoCD Application">
     Save the following manifest as `application.yaml`, adjusting the domain, version, and values to match your environment:
 
     ```yaml
@@ -428,12 +534,15 @@ If you manage your cluster with ArgoCD, you can point it directly at the OCI cha
     metadata:
       name: plexicus
       namespace: argocd
+      annotations:
+        # Defer until the five prerequisite Applications (sync-wave 0/1) are Healthy
+        argocd.argoproj.io/sync-wave: "5"
     spec:
       project: default
       source:
         repoURL: europe-west3-docker.pkg.dev/plexicus-registry/charts
         chart: plexicus
-        targetRevision: "1.1.0"  # replace with the latest version from the releases page
+        targetRevision: "1.2.0"
         helm:
           values: |
             global:

--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -156,9 +156,103 @@ kubectl create secret docker-registry gar-secret \
 
 ---
 
-## 6. Prepare a Minimal Values File \{#self-hosted_local-evaluation-8}
+## 6. Install Infrastructure Prerequisites \{#self-hosted_local-evaluation-8}
 
-Save the following as `values-local.yaml`. Unlike production, local evaluation can rely on the bundled MongoDB, Redis, PostgreSQL, and MinIO subcharts with shared bootstrap passwords:
+Plexicus depends on five infrastructure services (MongoDB, Redis, MinIO, PostgreSQL, Temporal). They are **not bundled** in the umbrella chart — bundling them produced an artifact that exceeded the 1 MB Kubernetes Secret limit Helm uses for release storage. Install each as a separate Helm release in the `plexicus` namespace.
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add temporal https://go.temporal.io/helm-charts
+helm repo update
+
+# 1. MongoDB
+helm upgrade --install mongodb bitnami/mongodb --version 18.6.15 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/mongodb \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/mongodb-exporter \
+  --set 'auth.rootPassword=localdev-password' \
+  --set 'auth.databases={plexicus}' \
+  --set 'auth.usernames={plexicus}' \
+  --set 'auth.passwords={localdev-password}' \
+  --wait
+
+# 2. Redis
+helm upgrade --install redis bitnami/redis --version 25.3.2 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/redis \
+  --set sentinel.image.repository=bitnamilegacy/redis-sentinel \
+  --set metrics.image.repository=bitnamilegacy/redis-exporter \
+  --set kubectl.image.repository=bitnamilegacy/kubectl \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set sysctl.image.repository=bitnamilegacy/os-shell \
+  --set auth.password=localdev-password \
+  --set replica.replicaCount=0 \
+  --wait
+
+# 3. MinIO
+helm upgrade --install minio bitnami/minio --version 17.0.21 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/minio \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set console.image.repository=bitnamilegacy/minio-object-browser \
+  --set apiIngress.enabled=false --set ingress.enabled=false \
+  --set auth.rootUser=minioadmin \
+  --set auth.rootPassword=localdev-password \
+  --set defaultBuckets=platform \
+  --wait
+
+# 4. PostgreSQL (for Temporal)
+helm upgrade --install temporal-postgresql bitnami/postgresql --version 18.5.6 -n plexicus \
+  --set global.security.allowInsecureImages=true \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set auth.postgresPassword=temporalpassword \
+  --wait
+
+# 5. Temporal
+helm upgrade --install temporal temporal/temporal --version 0.73.2 -n plexicus \
+  --set server.replicaCount=1 \
+  --set cassandra.enabled=false --set elasticsearch.enabled=false \
+  --set prometheus.enabled=false --set grafana.enabled=false \
+  --set server.config.persistence.default.driver=sql \
+  --set server.config.persistence.default.sql.driver=postgres12 \
+  --set server.config.persistence.default.sql.host=temporal-postgresql \
+  --set server.config.persistence.default.sql.port=5432 \
+  --set server.config.persistence.default.sql.database=temporal \
+  --set server.config.persistence.default.sql.user=postgres \
+  --set server.config.persistence.default.sql.password=temporalpassword \
+  --set server.config.persistence.visibility.driver=sql \
+  --set server.config.persistence.visibility.sql.driver=postgres12 \
+  --set server.config.persistence.visibility.sql.host=temporal-postgresql \
+  --set server.config.persistence.visibility.sql.port=5432 \
+  --set server.config.persistence.visibility.sql.database=temporal_visibility \
+  --set server.config.persistence.visibility.sql.user=postgres \
+  --set server.config.persistence.visibility.sql.password=temporalpassword
+
+kubectl -n plexicus get pods   # confirm all 5 prereqs are Running before continuing
+```
+
+:::warning Apple Silicon (arm64) Macs
+Bitnami's free **legacy** images are amd64-only and will fail to pull on an arm64 cluster (`no match for platform in manifest`). On Apple Silicon, replace the `bitnamilegacy/*` overrides with multi-arch upstream images for evaluation:
+
+```bash
+# Example for MongoDB on arm64
+helm upgrade --install mongodb bitnami/mongodb --version 18.6.15 -n plexicus \
+  --set image.repository=mongo --set image.tag=8.0 \
+  --set global.security.allowInsecureImages=true \
+  ...   # other overrides become unnecessary or use upstream multi-arch alternatives
+```
+
+For full evaluation on arm64 we recommend deploying the prereqs from the upstream multi-arch images (`mongo:8.0`, `redis:7-alpine`, `minio/minio`, `postgres:15-alpine`, `temporalio/auto-setup:1.29`) via plain `Deployment` + `Service` manifests. A reference manifest set is available on request — contact **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)**.
+
+For production, deploy on an amd64 Kubernetes cluster (the standard cloud K8s offerings) — Bitnami legacy images work there as documented above.
+:::
+
+## 7. Prepare a Minimal Values File \{#self-hosted_local-evaluation-9}
+
+Save the following as `values-local.yaml`. The five services above are reached via their default in-cluster service names (`mongodb`, `redis-master`, `minio`, `temporal-postgresql`, `temporal-frontend`).
 
 Local evaluation uses the same `global.ingressClassName` and `global.certManager` fields as production — only the values change (nginx + self-signed instead of traefik + letsencrypt-prod).
 
@@ -171,23 +265,26 @@ global:
   certManager:
     enabled: true
     clusterIssuer: "selfsigned-issuer"
+  imagePullSecrets:
+    - name: gar-secret
   required:
     database:
-      host: "plexicus-mongodb"
+      host: "mongodb"
       name: "plexicus"
       port: 27017
-      username: "plexicus"
+      username: "root"
       options: "authSource=admin"
       password: "localdev-password"
     redis:
-      host: "plexicus-redis-master"
+      host: "redis-master"
       port: 6379
       password: "localdev-password"
     minio:
-      rootUser: "plexicus"
+      service: "minio:9000"
+      rootUser: "minioadmin"
       rootPassword: "localdev-password"
     postgresql:
-      password: "localdev-password"
+      password: "temporalpassword"
 
 fastapi:
   ingress:
@@ -214,7 +311,7 @@ For local evaluation, application secrets (OAuth client secrets, OpenAI API key,
 
 ---
 
-## 7. Install the Chart \{#self-hosted_local-evaluation-9}
+## 8. Install the Chart \{#self-hosted_local-evaluation-10}
 
 Set the chart version (your Plexicus contact provides this when you receive registry credentials, or contact **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)** for the current version):
 
@@ -236,7 +333,7 @@ kubectl get pods -n plexicus -w
 
 ---
 
-## 8. Access the Platform \{#self-hosted_local-evaluation-10}
+## 9. Access the Platform \{#self-hosted_local-evaluation-11}
 
 Open your browser at:
 


### PR DESCRIPTION
## Summary

Customer-facing alignment with chart **1.2.0** structural changes uncovered during end-to-end install validation. The five infrastructure subcharts (MongoDB, Redis, MinIO, PostgreSQL, Temporal) are **no longer bundled** in the umbrella chart — bundling them pushed the chart `.tgz` over the 1 MB Kubernetes Secret limit Helm enforces for release storage.

## What changed

| File | Change |
|------|--------|
| `helm-chart.mdx` | Added **Step 6: Install Infrastructure Prerequisites** with full `helm upgrade --install` commands (bitnamilegacy/* image overrides). Added prereq Applications step to the ArgoCD section (sync-wave 0/1) ahead of the umbrella Application (sync-wave 5). |
| `local-evaluation.mdx` | Same prereq-install step for the eval path. Added an **Apple Silicon (arm64) callout** — Bitnami legacy images are amd64-only and require multi-arch upstream alternatives (`mongo:8.0`, `redis:7-alpine`, `minio/minio`, `postgres:15-alpine`, `temporalio/auto-setup:1.29`) on M-series Macs. Renumbered subsequent steps. |
| `air-gapped.mdx` | Image-mirroring procedure now lists the prereq images (mongodb, redis, minio, postgresql, temporal + Bitnami init/sidecar images) alongside the 8 Plexicus service images. Added Bitnami licensing-change callout (free legacy at `bitnamilegacy/*`). |
| `configuration/index.mdx` | "External dependencies (BYO Redis/Temporal/MongoDB)" matrix row updated from **Optional** to **Required** — chart 1.2.0+ no longer bundles these. |

## Why

The structural change is documented in the chart's own `CHANGELOG.md` (v1.2.0) and bundled `docs/getting-started.md`. These self-hosted pages are the customer-discoverable mirror published at `docs.plexicus.ai/docs/self-hosted/...`.

Pairs with chart-side commits on `feature/argocd-gitops-semver` of `plexicus/platform-charts` (commits `f931f00` + `761f774`).

## Test plan

- [ ] Verify the new "Install Infrastructure Prerequisites" section renders correctly in helm-chart.mdx and local-evaluation.mdx
- [ ] Confirm the ArgoCD section now shows two Step components (prereqs + umbrella) with sync-wave annotations
- [ ] Verify the Apple Silicon callout in local-evaluation.mdx is visually highlighted (`:::warning`)
- [ ] Confirm the configuration matrix shows "Required" for infrastructure prerequisites
- [ ] All existing heading IDs (\#self-hosted_*-N) preserved for stable URLs
- [ ] No private-repo links (audited as part of PR #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)