### PR TITLE
docs(self-hosted): Tier-C browser-OAuth flow + scrub stale kind-as-primary refs

### DIFF
--- a/docs/self-hosted/helm-chart.mdx
+++ b/docs/self-hosted/helm-chart.mdx
@@ -505,6 +505,54 @@ A `200` with an `access_token` confirms the full chain — frontend → ingress 
 
 ---
 
+## 10. Connect a SCM and run your first scan \{#self-hosted_helm-chart-scm}
+
+:::warning Browser-only OAuth — by design
+Connecting GitHub / GitLab / Bitbucket / Gitea to Plexicus uses a standard OAuth 2.0 redirect flow. The user must complete the authorization in a browser — there is no API-only or Personal Access Token shortcut to skip the redirect. The bullet below assumes you already populated the SCM OAuth client credentials (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` etc.) when you created `plexicus-fastapi` in step 5; without those, the OAuth flow returns 400 from the provider.
+:::
+
+### 10.1 Connect the SCM via the UI \{#self-hosted_helm-chart-scm-connect}
+
+1. Sign in to `https://<your-domain>` with the admin user from step 9.
+2. Open the **Connectors** page in the left sidebar.
+3. Click your SCM (GitHub / GitLab / Bitbucket / Gitea) → **Connect**. The browser is redirected to the provider for authorization. Log in and approve.
+4. The provider redirects back to `https://api.<your-domain>/vulnerability_tool/callback/<provider>?code=…&state=…`. The callback stores the access_token + refresh_token on the user record in MongoDB.
+
+### 10.2 Add a repository \{#self-hosted_helm-chart-scm-add-repo}
+
+UI: **Applications** → **Add applications** → pick the SCM connector, choose the repo, set a nickname and branch, click **Create**.
+
+API equivalent (assumes the SCM is already connected per step 10.1):
+
+```bash
+curl -X POST https://api.<your-domain>/create_repository_with_list \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_control": "github",
+    "data": [
+      { "uri": "https://github.com/<owner>/<repo>",
+        "nickname": "First repo",
+        "branch": "main" }
+    ]
+  }'
+```
+
+### 10.3 Trigger a scan and read the findings \{#self-hosted_helm-chart-scm-scan}
+
+```bash
+curl -X POST https://api.<your-domain>/request_repo_scan \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"repository_id":"<id-from-step-10.2>","scan_type":"app"}'
+
+curl -H "Authorization: Bearer $TOKEN" https://api.<your-domain>/findings
+```
+
+Scan progress also surfaces in **Findings** in the UI as workers process the queue.
+
+---
+
 ## Day 2 References \{#self-hosted_helm-chart-day2}
 
 The chart artifact bundles operator documentation under `docs/`. After running `helm pull --untar` (see step 6), the following guides are available locally:

--- a/docs/self-hosted/index.mdx
+++ b/docs/self-hosted/index.mdx
@@ -19,7 +19,7 @@ Pick the guide that matches what you are trying to do:
 
 ### 🧪 I want to evaluate Plexicus locally \{#self-hosted_index-3}
 
-You want to spin up Plexicus on your laptop with [kind](https://kind.sigs.k8s.io/) or minikube, click around, and see if it solves your problem. You don't care about TLS, scaling, or production hardening yet.
+You want to spin up Plexicus on a small Ubuntu 24.04 server (cloud VM or on-premise) with [k3s](https://k3s.io/), click around, and see if it solves your problem. The Ubuntu + k3s recipe is what we validate end-to-end and ship as the recommended evaluator path; the macOS / kind / Docker Desktop variant is documented as a fallback appendix.
 
 → **[Local Evaluation (Self-Signed)](/docs/self-hosted/local-evaluation)**
 

--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -466,7 +466,58 @@ curl -k -s -X POST \
 
 A `200` with an `access_token` confirms the full chain — frontend → ingress → fastapi → MongoDB authentication — is healthy. From here, open `https://plexicus.local` in a browser (accept the self-signed certificate warning) and sign in with the credentials you just registered.
 
-## 12. Cleanup \{#self-hosted_local-evaluation-cleanup}
+## 12. Connect a SCM and run your first scan \{#self-hosted_local-evaluation-scm}
+
+:::warning Browser-only OAuth — by design
+Connecting GitHub / GitLab / Bitbucket to Plexicus uses a standard OAuth 2.0 redirect flow. The user must complete the authorization in a browser — there is no API-only or PAT-only shortcut to skip the redirect. Plan your eval session accordingly.
+:::
+
+### 12.1 Connect GitHub via the UI \{#self-hosted_local-evaluation-scm-github}
+
+1. Sign in to `https://plexicus.local` with the admin user from step 11.
+2. Open the **Connectors** page (left sidebar).
+3. Click **GitHub → Connect**. The frontend calls `GET /vulnerability_tool/auth/github` (with your panel Bearer token) which returns an `authorization_url`.
+4. The browser is redirected to `github.com/login/oauth/authorize?client_id=…`. Log in to GitHub and click **Authorize Plexicus**.
+5. GitHub redirects back to `https://api.plexicus.local/vulnerability_tool/callback/github?code=…&state=…`. The callback exchanges the `code` for an access_token and refresh_token and stores them on the user record in MongoDB.
+
+The same UI flow works for GitLab, Bitbucket, and Gitea — pick the provider whose OAuth client credentials you supplied in your `secrets.txt` / values overlay.
+
+### 12.2 Add a repository \{#self-hosted_local-evaluation-scm-add-repo}
+
+Once a SCM is connected you can add repositories from the **Applications** page in the UI, or via the API:
+
+```bash
+curl -X POST https://api.plexicus.local/create_repository_with_list \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_control": "github",
+    "data": [
+      {
+        "uri": "https://github.com/<owner>/<repo>",
+        "nickname": "First repo",
+        "branch": "main"
+      }
+    ]
+  }'
+```
+
+### 12.3 Trigger a scan and read the findings \{#self-hosted_local-evaluation-scm-scan}
+
+```bash
+# Kick off a scan (the response includes the scan_id)
+curl -X POST https://api.plexicus.local/request_repo_scan \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"repository_id":"<id-from-step-12.2>","scan_type":"app"}'
+
+# Poll until status flips from running -> completed
+curl -H "Authorization: Bearer $TOKEN" https://api.plexicus.local/findings | jq '.data | length'
+```
+
+Findings appear under **Findings** in the UI as the scan completes.
+
+## 13. Cleanup \{#self-hosted_local-evaluation-cleanup}
 
 Removing the entire evaluation stack:
 


### PR DESCRIPTION
Two findings from the validation session: (1) Tier C connect-SCM-and-scan is browser-only by design — added explicit UI+API steps and a :::warning callout to both local-evaluation.mdx (new section 12) and helm-chart.mdx (new section 10). (2) index.mdx persona-router still described the evaluator path as 'kind or minikube on laptop' — reworded to point at the validated Ubuntu+k3s recipe. macOS/kind/Docker Desktop kept as fallback appendix.