### PR TITLE
docs(local-evaluation): remove example domains, drop macOS appendix, add missing secrets

### DIFF
--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -25,7 +25,7 @@ Self-signed certificates produce browser warnings and cannot be used by webhook 
 | RAM | **8 GB** | Less than 8 GB will OOMKill `fastapi` or schedule failures on `plexalyzer-*`. |
 | Disk | **50 GB** | The chart artifacts plus Plexicus container images consume ~10 GB; persistent volumes for MongoDB / MinIO / PostgreSQL add another ~5 GB. 50 GB leaves headroom for scan workloads. |
 | Network | **Public IP, ports 22/80/443 reachable** | k3s' built-in `klipper-lb` LoadBalancer assigns the node's public IP as the ingress EXTERNAL-IP, so the install procedure does not need an external load balancer or reverse proxy. |
-| DNS | Two hostnames pointing at the server's public IP | Either a real DNS record (`plexicus.eval.example.com`, `api.plexicus.eval.example.com`) or a per-machine `/etc/hosts` entry on each evaluator's laptop. The default chart values use `plexicus.local` / `api.plexicus.local` — adjust to fit. |
+| DNS | Two hostnames pointing at the server's public IP | Add `<server-ip> plexicus.local api.plexicus.local` to `/etc/hosts` on each evaluator's laptop (requires `sudo`). |
 | Plexicus registry credentials | A Google Cloud service account JSON (`keys.json`) | Provided by Plexicus when you request evaluation access. The chart pulls all custom images from `europe-west3-docker.pkg.dev` using this key. Email **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)** to obtain it. |
 
 If you do not have a server yet, any cloud VM (Hetzner, DigitalOcean, AWS Lightsail, GCP small instance, …) running stock Ubuntu 24.04 will do. The numbers above are the ones the procedure was actually validated against — **4 vCPU / 7.6 GiB RAM / 150 GB disk** completed Tier A + Tier B with comfortable headroom.
@@ -169,7 +169,7 @@ kubectl create secret docker-registry gar-secret \
 The Plexicus chart 1.2.0+ does **not** bundle MongoDB / Redis / MinIO / PostgreSQL / Temporal — bundling them pushed the chart `.tgz` over the 1 MB Kubernetes Secret limit Helm uses for release storage. Install each as its own Helm release in the `plexicus` namespace.
 
 :::note Bitnami licensing change (August 2025)
-Bitnami moved their official chart images to a paid distribution. Free legacy images live under `docker.io/bitnamilegacy/*`. The commands below override every image reference (main + init + sidecar containers) accordingly. The `bitnamilegacy/*` images are amd64-only — perfect for this Ubuntu evaluator path. (For arm64 macOS evaluation see the appendix at the bottom of this page.)
+Bitnami moved their official chart images to a paid distribution. Free legacy images live under `docker.io/bitnamilegacy/*`. The commands below override every image reference (main + init + sidecar containers) accordingly. The `bitnamilegacy/*` images are amd64-only — perfect for this Ubuntu evaluator path.
 :::
 
 ```bash
@@ -287,12 +287,23 @@ kubectl -n plexicus create secret generic plexicus-fastapi \
   --from-literal=GITHUB_CLIENT_SECRET="" \
   --from-literal=GITLAB_CLIENT_SECRET="" \
   --from-literal=BITBUCKET_CLIENT_SECRET="" \
+  --from-literal=BITBUCKET_ACCESS_TOKEN="" \
   --from-literal=MINIO_ROOT_PASSWORD="$MINIO_PASS" \
   --from-literal=SMTP_PASSWORD="" \
   --from-literal=OPENAI_API_KEY="" \
   --from-literal=BREAK_GLASS_SECRET_KEY="$BREAK_GLASS" \
   --from-literal=SSO_RELAY_STATE_SECRET="$SSO_RELAY" \
-  --from-literal=SSO_ENCRYPTION_KEY="$SSO_ENCRYPT"
+  --from-literal=SSO_ENCRYPTION_KEY="$SSO_ENCRYPT" \
+  --from-literal=DEPLOYMENT_MANAGER_OPENAI_API_KEY_FREE="" \
+  --from-literal=SWE_OPENAI_API_KEY="" \
+  --from-literal=STRIPE_API_KEY="" \
+  --from-literal=STRIPE_WEBHOOK_SECRET="" \
+  --from-literal=CANNY_PRIVATE_TOKEN="" \
+  --from-literal=POSTHOG_API_KEY="" \
+  --from-literal=POSTHOG_PERSONAL_API_KEY="" \
+  --from-literal=MAUTIC_AUTH="" \
+  --from-literal=MICROSOFT_MARKETPLACE_CLIENT_SECRET="" \
+  --from-literal=MICROSOFT_INSTRUMENTATION_KEY=""
 
 kubectl -n plexicus create secret generic plexicus-worker \
   --from-literal=DATABASE_PASSWORD="$DB_PASS" \
@@ -303,10 +314,19 @@ kubectl -n plexicus create secret generic plexicus-worker \
   --from-literal=MINIO_ROOT_PASSWORD="$MINIO_PASS" \
   --from-literal=PLEXALYZER_TOKEN="$PLEXALYZER_SECRET" \
   --from-literal=AZURE_RESOURCE_PASSWORD="" \
+  --from-literal=AZURE_RESOURCE_USERNAME="" \
   --from-literal=OPENAI_API_KEY="<your-openai-or-deepseek-or-azure-openai-key>"
 
 kubectl -n plexicus create secret generic plexicus-frontend \
-  --from-literal=NUXT_SECRET_KEY="$NUXT_SECRET"
+  --from-literal=NUXT_SECRET_KEY="$NUXT_SECRET" \
+  --from-literal=NUXT_GITHUB_SECRET_KEY="" \
+  --from-literal=NUXT_GITLAB_SECRET_KEY="" \
+  --from-literal=NUXT_BITBUCKET_CLOUD_SECRET="" \
+  --from-literal=NUXT_GOOGLE_CLIENT_SECRET="" \
+  --from-literal=NUXT_STRIPE_KEY="" \
+  --from-literal=NUXT_PILOTING_KEY="" \
+  --from-literal=NUXT_PILOTING_REMEDIATOR_KEY="" \
+  --from-literal=NUXT_TURNSTILE_SECRET_KEY=""
 
 kubectl -n plexicus create secret generic plexicus-analysis-scheduler \
   --from-literal=DATABASE_PASSWORD="$DB_PASS" \
@@ -321,11 +341,14 @@ kubectl -n plexicus create secret generic plexicus-exporter \
   --from-literal=DATABASE_PASSWORD="$DB_PASS" \
   --from-literal=OPENAI_API_KEY=""
 
-for s in plexalyzer-code plexalyzer-prov; do
-  kubectl -n plexicus create secret generic plexicus-$s \
-    --from-literal=PLEXALYZER_SECRET_KEY="$PLEXALYZER_SECRET" \
-    --from-literal=OPENAI_API_KEY=""
-done
+kubectl -n plexicus create secret generic plexicus-plexalyzer-code \
+  --from-literal=PLEXALYZER_SECRET_KEY="$PLEXALYZER_SECRET" \
+  --from-literal=OPENAI_API_KEY="" \
+  --from-literal=NVD_API_KEY=""
+
+kubectl -n plexicus create secret generic plexicus-plexalyzer-prov \
+  --from-literal=PLEXALYZER_SECRET_KEY="$PLEXALYZER_SECRET" \
+  --from-literal=OPENAI_API_KEY=""
 ```
 
 The empty values are fine for an evaluation install; features that depend on them (GitHub OAuth scanning, AI remediation, transactional email) will be unavailable until you fill them in.
@@ -653,13 +676,3 @@ Symptom: the SPA can't talk to `api.plexicus.local`. `curl -i -X OPTIONS -H "Ori
 
 Symptom: the Sandbox flow reaches "Scanning in progress" and the modal "Scanning taking longer than expected" appears after 15 minutes. Worker logs show `openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable`. Cause: the worker's `existingSecret` (`plexicus-worker`) is missing `OPENAI_API_KEY`. Fix: add it (`kubectl -n plexicus patch secret plexicus-worker --type=json -p='[{"op":"add","path":"/data/OPENAI_API_KEY","value":"<base64-of-your-deepseek-or-openai-key>"}]'`) and restart the worker. Chart 1.2.0+ wires the matching non-secret env vars (`OPENAI_BASE_URL`, `OPENAI_DEPLOYMENT_NAME`, `OPENAI_VERSION`) automatically.
 
----
-
-## Appendix — macOS evaluation via kind / Docker Desktop \{#self-hosted_local-evaluation-appendix-mac}
-
-Running the evaluator path on macOS is supported but adds two friction points the Linux/k3s path avoids:
-
-1. **arm64 Apple Silicon vs. amd64 images.** Plexicus container images and several Bitnami legacy images (notably `bitnamilegacy/mongodb`) are amd64-only. Docker Desktop's Rosetta-for-x86 emulation works in `KubernetesMode: kubeadm` but **not** in `kind` mode — verify Settings → Kubernetes shows "kubeadm" before installing the chart. For mongodb specifically, fall back to the upstream multi-arch `mongo:8.0` image deployed via a plain `Deployment` instead of the Bitnami chart.
-2. **Public-IP routing.** Docker Desktop's K8s LoadBalancer routes to `localhost`, so `https://plexicus.local` works only from the same Mac unless you forward ports to other devices.
-
-The Linux/k3s path above remains the recommended evaluator setup. For a true zero-cost local install, prefer a tiny Hetzner/DO/AWS Lightsail Ubuntu VM ($5/month) over fighting Docker Desktop.

--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -355,7 +355,7 @@ The empty values are fine for an evaluation install; features that depend on the
 
 ## 9. Prepare the Plexicus values overlay \{#self-hosted_local-evaluation-values}
 
-Save the following as `/root/values-evaluator.yaml`. Chart 1.2.0+ defaults the in-cluster service names (`mongodb`, `redis-master`, `minio:9000`, etc.), the AI endpoint (DeepSeek's OpenAI-compatible API), and the Turnstile keys (Cloudflare test tokens) — so the overlay only has to override the things specific to your cluster: the domain, the ingress class, the self-signed ClusterIssuer, the prereq passwords, and the per-service `existingSecret` references.
+Save the following as `/root/values-evaluator.yaml`. The overlay sets the domain, ingress class, self-signed ClusterIssuer, prereq passwords, per-service `existingSecret` references, and the full plain-text `envs` catalog for every service. Chart 1.2.0+ provides sensible defaults for the infrastructure variables (database host, Redis, MinIO, Temporal endpoints, Turnstile test tokens) — the values shown here match those defaults. Leave optional integration keys (OAuth, SMTP, Stripe, analytics) empty for a basic evaluation install and fill them in as you enable each feature.
 
 ```yaml
 global:
@@ -393,6 +393,75 @@ global:
 
 fastapi:
   existingSecret: plexicus-fastapi
+  envs:
+    # ── Infrastructure (chart defaults shown; override only if your prereq names differ) ──
+    BACKEND_HOST_URL: "https://api.plexicus.local"
+    FRONTEND_URL: "https://plexicus.local"
+    CORS_ORIGINS: "https://plexicus.local,https://api.plexicus.local"
+    DATABASE_HOST: "mongodb"
+    DATABASE_NAME: "plexicus"
+    DATABASE_USERNAME: "root"
+    DATABASE_PORT: "27017"
+    DATABASE_OPTIONS: ""
+    REDIS_HOST: "redis-master"
+    REDIS_PORT: "6379"
+    REDIS_WEBSOCKET_DB: "0"
+    MINIO_SERVICE: "minio:9000"
+    MINIO_ROOT_USER: "minioadmin"
+    MINIO_DEFAULT_BUCKETS: "platform"
+    TEMPORAL_GRPC_ENDPOINT: "temporal-frontend:7233"
+    TEMPORAL_NAMESPACE: "default"
+    PLEXALYZER_SERVER: "plexalyzer-code"
+    RULE_ENRICHER_SERVER: ""
+    WORKER_ENDPOINT: ""
+    REPOSITORY_WEBHOOK: ""
+    # ── General ──
+    ENVIRONMENT: "production"
+    CLOUD_PROVIDER: ""
+    GELF_LOGGING: "false"
+    OAUTHLIB_INSECURE_TRANSPORT: "0"
+    GOOGLE_CLOUD_PROJECT_ID: ""
+    SCIM_TOKEN_DEFAULT_EXPIRY_DAYS: "365"
+    WEBAUTHN_RP_ID: "plexicus.local"
+    WEBAUTHN_ORIGIN: "https://plexicus.local"
+    # ── SCM OAuth (fill in after registering apps — see production guide) ──
+    GITHUB_APP_ID: ""
+    GITHUB_CLIENT_ID: ""
+    GITHUB_CALLBACK: ""
+    GITHUB_REDIRECT_URI: ""
+    GITHUB_INSTALLATION_URL: ""
+    GITLAB_CLIENT_ID: ""
+    GITLAB_REDIRECT_URI: ""
+    BITBUCKET_CLIENT_ID: ""
+    BITBUCKET_REDIRECT_URI: ""
+    # ── SMTP / transactional email ──
+    SMTP_SERVER: ""
+    SMTP_PORT: "587"
+    SMTP_USERNAME: ""
+    SMTP_FRONTEND_URL: "https://plexicus.local"
+    SMTP_RESET_PASSWORD_URL: ""
+    SMTP_VERIFY_URL: ""
+    # ── AI — free / piloting tier (companion API keys go in step 8 secret) ──
+    FREE_AI_REMEDIATION_PROVIDER_TYPE: ""
+    FREE_AI_VALIDATION_PROVIDER_TYPE: ""
+    DEPLOYMENT_MANAGER_OPENAI_BASE_URL_FREE: ""
+    DEPLOYMENT_MANAGER_OPENAI_DEPLOYMENT_NAME_FREE: ""
+    DEPLOYMENT_MANAGER_OPENAI_VERSION_FREE: ""
+    SWE_OPENAI_BASE_URL: ""
+    SWE_OPENAI_DEPLOYMENT_NAME: ""
+    SWE_OPENAI_VERSION: ""
+    # ── Stripe ──
+    STRIPE_CANCEL_URL: ""
+    STRIPE_SUCCESS_URL: ""
+    # ── Analytics / CRM (optional for eval installs) ──
+    POSTHOG_HOST_URL: ""
+    POSTHOG_PROJECT_ID: ""
+    MAUTIC_URL: ""
+    MAUTIC_TIMEOUT: "30"
+    MAUTIC_VERIFY_SSL: "true"
+    # ── Microsoft Marketplace ──
+    MICROSOFT_MARKETPLACE_CLIENT_ID: ""
+    MICROSOFT_MARKETPLACE_TENANT_ID: ""
   ingress:
     enabled: true
     hosts:
@@ -405,6 +474,47 @@ fastapi:
 
 frontend:
   existingSecret: plexicus-frontend
+  envs:
+    NODE_OPTIONS: ""
+    # ── Public runtime config ──
+    NUXT_PUBLIC_BACKEND_HOST_URL: "https://api.plexicus.local"
+    NUXT_PUBLIC_WEB_HOST_URL: "https://plexicus.local"
+    NUXT_PUBLIC_WEBSOCKET_URL: "wss://api.plexicus.local"
+    # ── Turnstile (chart 1.2.0+ defaults to Cloudflare test tokens for eval) ──
+    NUXT_PUBLIC_TURNSTILE_SITE_KEY: ""
+    NUXT_TURNSTILE_TEST_SUCCESS_TOKEN: ""
+    # ── SCM OAuth ──
+    NUXT_GITHUB_CLIENT_ID: ""
+    NUXT_GITHUB_CALLBACK_URL: ""
+    NUXT_PUBLIC_GITHUB_INSTALLATION_URL: ""
+    NUXT_GITLAB_CLIENT_ID: ""
+    NUXT_GITLAB_CALLBACK_URL: ""
+    NUXT_BITBUCKET_CLOUD_KEY: ""
+    NUXT_BITBUCKET_CLOUD_CALLBACK_URL: ""
+    NUXT_PUBLIC_GOOGLE_CLIENT_ID: ""
+    # ── Stripe ──
+    NUXT_PUBLIC_STRIPE_KEY: ""
+    # ── AI piloting ──
+    NUXT_PILOTING_ENDPOINT: ""
+    NUXT_PILOTING_DEPLOYMENT: ""
+    NUXT_PILOTING_VERSION: ""
+    NUXT_PILOTING_REMEDIATOR_ENDPOINT: ""
+    NUXT_PILOTING_REMEDIATOR_DEPLOYMENT: ""
+    NUXT_PILOTING_REMEDIATOR_VERSION: ""
+    # ── Canny feedback widget ──
+    NUXT_CANNY_APP_ID: ""
+    NUXT_CANNY_BOARD_TOKEN: ""
+    # ── Firebase (optional — for system-status page) ──
+    NUXT_PUBLIC_FIREBASE_API_KEY: ""
+    NUXT_PUBLIC_FIREBASE_APP_ID: ""
+    NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ""
+    NUXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ""
+    NUXT_PUBLIC_FIREBASE_PROJECT_ID: ""
+    NUXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ""
+    NUXT_PUBLIC_FIREBASE_SYSTEM_STATUS_DOC_ID: ""
+    # ── Analytics ──
+    NUXT_PUBLIC_GOOGLE_TAG_MANAGER_ID: ""
+    NUXT_PUBLIC_INSTRUMENTATION_KEY: ""
   ingress:
     enabled: true
     hosts:
@@ -415,12 +525,87 @@ frontend:
       - secretName: plexicus-frontend-tls
         hosts: [plexicus.local]
 
-worker:             { existingSecret: plexicus-worker }
-analysis-scheduler: { existingSecret: plexicus-analysis-scheduler }
-codex-remedium:     { existingSecret: plexicus-codex-remedium }
-exporter:           { existingSecret: plexicus-exporter }
-plexalyzer-code:    { existingSecret: plexicus-plexalyzer-code }
-plexalyzer-prov:    { existingSecret: plexicus-plexalyzer-prov }
+worker:
+  existingSecret: plexicus-worker
+  envs:
+    BACKEND_HOST_URL: "https://api.plexicus.local"
+    DATABASE_HOST: "mongodb"
+    DATABASE_NAME: "plexicus"
+    DATABASE_USERNAME: "root"
+    DATABASE_PORT: "27017"
+    DATABASE_OPTIONS: ""
+    REDIS_HOST: "redis-master"
+    REDIS_PORT: "6379"
+    REDIS_WORKER_DB: "0"
+    MINIO_SERVICE: "minio:9000"
+    MINIO_ROOT_USER: "minioadmin"
+    MINIO_DEFAULT_BUCKETS: "platform"
+    TEMPORAL_GRPC_ENDPOINT: "temporal-frontend:7233"
+    TEMPORAL_NAMESPACE: "default"
+    PLEXALYZER_SERVER: "plexalyzer-code"
+    PLEXALYZER_PORT: "50051"
+    GITHUB_APP_ID: ""
+    IMPORTER_FASTAPI_URL: ""
+    MESSAGE_URL: ""
+    NOTIFICATION_WEBSOCKET_URL: ""
+    REMEDIATION_URL: ""
+    REPOSITORY_WEBHOOK: ""
+    WORKER_ENDPOINT: ""
+    GELF_LOGGING: "false"
+    GAR_LOCATION: ""
+    GAR_PROJECT_ID: ""
+    GAR_REPOSITORY: ""
+
+analysis-scheduler:
+  existingSecret: plexicus-analysis-scheduler
+  envs:
+    DATABASE_HOST: "mongodb"
+    DATABASE_NAME: "plexicus"
+    DATABASE_USERNAME: "root"
+    DATABASE_PORT: "27017"
+    DATABASE_OPTIONS: ""
+    TEMPORAL_GRPC_ENDPOINT: "temporal-frontend:7233"
+    TEMPORAL_NAMESPACE: "default"
+    GELF_LOGGING: "false"
+
+codex-remedium:
+  existingSecret: plexicus-codex-remedium
+  envs:
+    DATABASE_HOST: "mongodb"
+    DATABASE_NAME: "plexicus"
+    DATABASE_USERNAME: "root"
+    DATABASE_PORT: "27017"
+    DATABASE_OPTIONS: ""
+    REDIS_HOST: "redis-master"
+    REDIS_PORT: "6379"
+    REDIS_WORKER_DB: "0"
+    REMEDIATION_URL: ""
+
+exporter:
+  existingSecret: plexicus-exporter
+  envs:
+    DATABASE_HOST: "mongodb"
+    DATABASE_NAME: "plexicus"
+    DATABASE_USERNAME: "root"
+    DATABASE_PORT: "27017"
+    DATABASE_OPTIONS: ""
+    GELF_LOGGING: "false"
+    AI_PROVIDER_TYPE: ""
+    OPENAI_BASE_URL: ""
+    OPENAI_DEPLOYMENT_NAME: ""
+    OPENAI_VERSION: ""
+
+plexalyzer-code:
+  existingSecret: plexicus-plexalyzer-code
+  envs:
+    MESSAGE_URL: ""
+    GELF_LOGGING: "false"
+
+plexalyzer-prov:
+  existingSecret: plexicus-plexalyzer-prov
+  envs:
+    MESSAGE_URL: ""
+    GELF_LOGGING: "false"
 ```
 
 ## 10. Install the Plexicus chart \{#self-hosted_local-evaluation-install}


### PR DESCRIPTION
## Summary

- **DNS prereq row**: simplified to only reference `plexicus.local` / `api.plexicus.local` via `/etc/hosts` — removed the `plexicus.eval.example.com` example domain alternatives and the "adjust to fit" note
- **macOS appendix removed**: deleted the _Appendix — macOS evaluation via kind / Docker Desktop_ section and its cross-reference in the Bitnami licensing note
- **Section 8 — missing secrets added** (sourced from `secrets-dev.yaml` audit):
  - `plexicus-fastapi`: +11 keys (`DEPLOYMENT_MANAGER_OPENAI_API_KEY_FREE`, `SWE_OPENAI_API_KEY`, `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`, `CANNY_PRIVATE_TOKEN`, `POSTHOG_API_KEY`, `POSTHOG_PERSONAL_API_KEY`, `MAUTIC_AUTH`, `MICROSOFT_MARKETPLACE_CLIENT_SECRET`, `MICROSOFT_INSTRUMENTATION_KEY`, `BITBUCKET_ACCESS_TOKEN`)
  - `plexicus-worker`: +`AZURE_RESOURCE_USERNAME`
  - `plexicus-frontend`: +8 keys (`NUXT_GITHUB_SECRET_KEY`, `NUXT_GITLAB_SECRET_KEY`, `NUXT_BITBUCKET_CLOUD_SECRET`, `NUXT_GOOGLE_CLIENT_SECRET`, `NUXT_STRIPE_KEY`, `NUXT_PILOTING_KEY`, `NUXT_PILOTING_REMEDIATOR_KEY`, `NUXT_TURNSTILE_SECRET_KEY`)
  - `plexicus-plexalyzer-code`: +`NVD_API_KEY`; split the shared for-loop into two separate `kubectl` commands so only `plexalyzer-code` gets the NVD key

All new secret entries default to `""` — evaluation installs work without them; operators fill in real values to unlock the respective features.

## Test plan

- [ ] Verify DNS row in prereqs table no longer mentions `plexicus.eval.example.com`
- [ ] Confirm macOS appendix heading and body are absent from the rendered page
- [ ] Confirm Bitnami note no longer references the appendix
- [ ] Check section 8 bash block contains all 21 previously-missing `🔐` secrets
- [ ] Confirm `plexalyzer-code` and `plexalyzer-prov` are now separate `kubectl` commands
- [ ] Confirm `plexalyzer-code` has `NVD_API_KEY` and `plexalyzer-prov` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)