### PR TITLE
docs(local-evaluation): fix evaluator UX — remove Tier A/B text and add API cert warning

### DIFF
--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -28,7 +28,7 @@ Self-signed certificates produce browser warnings and cannot be used by webhook 
 | DNS | Two hostnames pointing at the server's public IP | Add `<server-ip> plexicus.local api.plexicus.local` to `/etc/hosts` on each evaluator's laptop (requires `sudo`). |
 | Plexicus registry credentials | A Google Cloud service account JSON (`keys.json`) | Provided by Plexicus when you request evaluation access. The chart pulls all custom images from `europe-west3-docker.pkg.dev` using this key. Email **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)** to obtain it. |
 
-If you do not have a server yet, any cloud VM (Hetzner, DigitalOcean, AWS Lightsail, GCP small instance, …) running stock Ubuntu 24.04 will do. The numbers above are the ones the procedure was actually validated against — **4 vCPU / 7.6 GiB RAM / 150 GB disk** completed Tier A + Tier B with comfortable headroom.
+If you do not have a server yet, any cloud VM (Hetzner, DigitalOcean, AWS Lightsail, GCP small instance, …) running stock Ubuntu 24.04 will do. The numbers above are the ones the procedure was actually validated against — **4 vCPU / 7.6 GiB RAM / 150 GB disk** with comfortable headroom.
 
 ### Where you run each command
 
@@ -730,6 +730,10 @@ For the production path with real GitHub / GitLab / Bitbucket OAuth, see [§12.a
 ### 12.1 Sign in to the panel \{#self-hosted_local-evaluation-scm-signin}
 
 Open `https://plexicus.local` in your browser. You will see the certificate-warning page (the install uses a self-signed issuer). Accept the warning — on Chrome type `thisisunsafe` directly on the page; on Firefox / Safari click **Advanced → Proceed**.
+
+:::warning Accept the API certificate too
+Before signing in, open **`https://api.plexicus.local`** in a separate browser tab and accept the same certificate warning using the same method. The browser treats the two hostnames as separate origins and must trust each one independently. If `api.plexicus.local` is not accepted, login requests from the SPA will be silently blocked and the sign-in button will appear to do nothing.
+:::
 
 Sign in with the admin email and password you bootstrapped in step 11.
 


### PR DESCRIPTION
## Summary

- Remove the **"Tier A + Tier B"** phrase from the prerequisites section — it referenced an internal evaluation framework that external evaluators have no context for, causing confusion
- Add a `:::warning` admonition in **step 12.1** instructing evaluators to accept the self-signed certificate for `https://api.plexicus.local` *before* signing in — the browser treats each hostname as a separate origin and must trust each one independently; skipping this causes the login button to silently do nothing

## Test plan

- [ ] Confirm prerequisites table paragraph no longer mentions "Tier A" or "Tier B"
- [ ] Confirm step 12.1 shows the new warning admonition with instructions for both `https://plexicus.local` and `https://api.plexicus.local`
- [ ] Doc site builds without errors (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)