### PR TITLE
docs(evaluator): fix UX improvements and slim values overlay for chart v1.2.1

### DIFF
--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -405,6 +405,11 @@ fastapi:
     MAUTIC_URL: ""
     MAUTIC_TIMEOUT: "30"
     MAUTIC_VERIFY_SSL: "true"
+    # FastAPI passes plexalyzer connection info into Temporal workflow args.
+    # Without these, the worker receives namespace=None and port=None, which
+    # causes ConnectionError: Couldn't connect to the None on every scan.
+    PLEXALYZER_NAMESPACE: "plexicus"
+    PLEXALYZER_PORT: "8007"
   ingress:
     enabled: true
     hosts:
@@ -435,7 +440,21 @@ worker:
   envs:
     # ── Overrides: differ from chart global.required.* defaults ──
     DATABASE_OPTIONS: ""
-    PLEXALYZER_PORT: "50051"
+    # PLEXALYZER_PORT must match the port plexalyzer-code actually listens on
+    # (uvicorn on 0.0.0.0:8007). The chart default ships "50051" which is wrong
+    # and causes ConnectionError: Couldn't connect to the None in every scan.
+    PLEXALYZER_PORT: "8007"
+    # PLEXALYZER_NAMESPACE tells the worker which K8s namespace to search when
+    # resolving the plexalyzer pod IP via the Kubernetes API. Without this the
+    # namespace is None and get_pod_ip() raises ConnectionError on every scan.
+    PLEXALYZER_NAMESPACE: "plexicus"
+    # GAR_* env vars tell create_job() to pull dynamic plexalyzer scan pods
+    # from Google Artifact Registry. Without them the worker falls back to
+    # Azure ACR (no credentials here) and create_job() returns None silently,
+    # causing every scan to fail before any tools run.
+    GAR_LOCATION: "europe-west3"
+    GAR_PROJECT_ID: "plexicus-registry"
+    GAR_REPOSITORY: "platform-standalone"
 
 analysis-scheduler:
   existingSecret: plexicus-analysis-scheduler
@@ -456,11 +475,41 @@ exporter:
     DATABASE_OPTIONS: ""
     AI_PROVIDER_TYPE: ""           # new env not yet in chart values.yaml
 
+exporter:
+  # Disable the exporter on chart 1.2.1 — all published image tags (1.0.386,
+  # 1.0.395, latest) crash at startup with:
+  #   ImportError: cannot import name '_QUERY_OPTIONS' from 'pymongo.cursor'
+  # This is a pymongo/motor version conflict inside the exporter image that
+  # has no workaround short of a rebuilt image. Disabling it does not affect
+  # the core scan pipeline.
+  enabled: false
+  existingSecret: plexicus-exporter
+  envs:
+    DATABASE_OPTIONS: ""
+    AI_PROVIDER_TYPE: ""
+
 plexalyzer-code:
   existingSecret: plexicus-plexalyzer-code
+  # On servers with fewer than 4 vCPU / high CPU contention, the default
+  # request of 500m per plexalyzer pod may leave the pod Pending because the
+  # node is already at its CPU request limit. Lower to 100m for evaluation.
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "500Mi"
+    limits:
+      cpu: "1"
+      memory: "2000Mi"
 
 plexalyzer-prov:
   existingSecret: plexicus-plexalyzer-prov
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "500Mi"
+    limits:
+      cpu: "1"
+      memory: "2000Mi"
 ```
 
 ## 10. Install the Plexicus chart \{#self-hosted_local-evaluation-install}
@@ -479,7 +528,9 @@ helm upgrade --install plexicus \
   oci://europe-west3-docker.pkg.dev/plexicus-registry/charts/plexicus \
   --version $CHART_VERSION \
   --namespace plexicus \
-  -f /root/values-evaluator.yaml
+  -f /root/values-evaluator.yaml \
+  --set exporter.enabled=false \
+  --set global.required.oauth.google.clientId=placeholder.apps.googleusercontent.com
 ```
 
 Watch pods come up:
@@ -715,6 +766,97 @@ Symptom: filling in the form and clicking Login shows the inline error banner "T
 ### `400 Disallowed CORS origin` from API after login \{#self-hosted_local-evaluation-tt-cors}
 
 Symptom: the SPA can't talk to `api.plexicus.local`. `curl -i -X OPTIONS -H "Origin: https://plexicus.local" .../login` returns `400 Disallowed CORS origin`. Cause: FastAPI reads `CORS_ORIGINS` at startup and `https://plexicus.local` is not in the allow-list (or the env is empty). Fix: chart 1.2.0+ defaults `CORS_ORIGINS` to `<scheme>://<domain>,<scheme>://api.<domain>`. If you're on an older artifact, `kubectl -n plexicus set env deploy/fastapi CORS_ORIGINS=https://plexicus.local,https://api.plexicus.local` and restart the FastAPI rollout.
+
+### `exporter` pod crashes with `ImportError: cannot import name '_QUERY_OPTIONS'` \{#self-hosted_local-evaluation-tt-exporter-pymongo}
+
+Symptom: `exporter` pod is in `CrashLoopBackOff`; logs show `ImportError: cannot import name '_QUERY_OPTIONS' from 'pymongo.cursor'`. All published exporter image tags (1.0.386, 1.0.395, latest) are affected by a pymongo/motor version conflict. Fix: disable the exporter in your values overlay and helm upgrade command — it is not part of the core scan pipeline:
+
+```yaml
+# values-evaluator.yaml
+exporter:
+  enabled: false
+```
+
+```bash
+helm upgrade plexicus … --set exporter.enabled=false
+```
+
+### Worker logs `ConnectionError: Couldn't connect to the None` on every scan \{#self-hosted_local-evaluation-tt-plexalyzer-namespace}
+
+Symptom: `kubectl -n plexicus logs deployment/worker -c worker` shows:
+
+```
+ConnectionError: Couldn't connect to the None. Retrying...
+temporalio.activity - WARNING - Completing activity as failed … activity_type: get_plexalyzer_pod_ip
+```
+
+Cause: `PLEXALYZER_NAMESPACE` is not set in the worker (and fastapi) deployments, so the worker receives `namespace=None` when the Temporal workflow tries to resolve the plexalyzer pod IP via the Kubernetes API. Additionally, `PLEXALYZER_PORT` defaults to `50051` in the chart but plexalyzer-code listens on `8007`.
+
+Fix: add both env vars to `fastapi.envs` and `worker.envs` in the values overlay (already included in the step 9 template above):
+
+```yaml
+PLEXALYZER_NAMESPACE: "plexicus"
+PLEXALYZER_PORT: "8007"
+```
+
+Then `helm upgrade` to apply.
+
+### `plexalyzer-code` / `plexalyzer-prov` pods stuck in `Pending` \{#self-hosted_local-evaluation-tt-plexalyzer-pending}
+
+Symptom: `kubectl -n plexicus describe pod -l app.kubernetes.io/name=plexalyzer-code` shows `Insufficient cpu`. Cause: the default chart requests 500m CPU per plexalyzer pod. On a 4-vCPU node under load, the available CPU budget may already be committed by the other services, leaving no room. Fix: lower the CPU request in the values overlay:
+
+```yaml
+plexalyzer-code:
+  resources:
+    requests:
+      cpu: "100m"
+plexalyzer-prov:
+  resources:
+    requests:
+      cpu: "100m"
+```
+
+### Frontend returns `500 [GoogleSignInPlugin]: clientId is required` \{#self-hosted_local-evaluation-tt-google-clientid}
+
+Symptom: opening `https://plexicus.local` returns an error page with `[GoogleSignInPlugin]: clientId is required`. Cause: the frontend Nuxt plugin requires `global.required.oauth.google.clientId` to be a non-empty string, even when Google OAuth is not used. Fix: pass a placeholder value at install time:
+
+```bash
+helm upgrade plexicus … \
+  --set global.required.oauth.google.clientId=placeholder.apps.googleusercontent.com
+```
+
+For production, replace the placeholder with a real Google OAuth client ID from [console.cloud.google.com](https://console.cloud.google.com).
+
+### `create_job() returned None` — scan starts but no plexalyzer job appears \{#self-hosted_local-evaluation-tt-gar-env}
+
+Symptom: worker logs show the scan workflow starts (activities `get_client`, `get_repository`, `create_scan_request` succeed) but `get_plexalyzer_pod_ip` immediately fails with `ConnectionError: Couldn't connect to the None`. No new plexalyzer Job appears under `kubectl -n plexicus get jobs`.
+
+Cause: `GAR_LOCATION`, `GAR_PROJECT_ID`, `GAR_REPOSITORY` are not set on the worker. The worker's `create_job()` function dynamically spawns a per-scan plexalyzer pod from GAR. When those three env vars are absent, the code silently falls back to Azure Container Registry (`crplexicus.azurecr.io`) which has no credentials in this install, so `create_job()` raises an exception and returns `None`. The subsequent `get_pod_ip(namespace, None)` call produces the misleading "connect to the None" error.
+
+Fix: add the three GAR vars to `worker.envs` in the values overlay (already included in the step 9 template above):
+
+```yaml
+worker:
+  envs:
+    GAR_LOCATION: "europe-west3"
+    GAR_PROJECT_ID: "plexicus-registry"
+    GAR_REPOSITORY: "platform-standalone"
+```
+
+Then `helm upgrade` to apply.
+
+### Worker RBAC 403 when cleaning up plexalyzer job after scan \{#self-hosted_local-evaluation-tt-job-delete-rbac}
+
+Symptom: scan completes successfully but worker logs show a 403 `Forbidden` error: `jobs.batch "plexalyzer-code-…" is forbidden: User "system:serviceaccount:plexicus:worker" cannot delete resource "jobs"`. The scan result is not affected, but the ephemeral plexalyzer Job pod is not cleaned up.
+
+Cause: the chart's `plexicus-worker-pod-manager` Role grants `create` on `batch/jobs` but not `delete`. Fix: patch the role to add `delete`:
+
+```bash
+kubectl -n plexicus patch role plexicus-worker-pod-manager --type=json \
+  -p='[{"op":"add","path":"/rules/2/verbs/-","value":"delete"}]'
+```
+
+Note: `helm upgrade` will revert this patch. A permanent fix requires updating the chart's RBAC template to include `delete` in the `batch/jobs` rule.
 
 ### Scan stays at "Scanning in progress" forever \{#self-hosted_local-evaluation-tt-scan-stuck}
 

--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -439,19 +439,6 @@ exporter:
   existingSecret: plexicus-exporter
   replicaCount: 0
 
-exporter:
-  # Disable the exporter on chart 1.2.1 — all published image tags (1.0.386,
-  # 1.0.395, latest) crash at startup with:
-  #   ImportError: cannot import name '_QUERY_OPTIONS' from 'pymongo.cursor'
-  # This is a pymongo/motor version conflict inside the exporter image that
-  # has no workaround short of a rebuilt image. Disabling it does not affect
-  # the core scan pipeline.
-  enabled: false
-  existingSecret: plexicus-exporter
-  envs:
-    DATABASE_OPTIONS: ""
-    AI_PROVIDER_TYPE: ""
-
 plexalyzer-code:
   existingSecret: plexicus-plexalyzer-code
   replicaCount: 0


### PR DESCRIPTION
## Summary

- Remove confusing "Tier A/B" phrasing from evaluator prerequisites and add API cert warning so self-signed cert for `https://api.plexicus.local` is accepted before login (fixes silent SPA auth failures)
- Replace verbose `values-evaluator.yaml` (~250 lines) with a minimal overlay (~80 lines) listing only intentional overrides and new envs not yet wired into chart defaults
- Fix incorrect empty-string overrides that were disabling env vars already provided by `global.required.*` anchors in `values.yaml`
- Bump chart version references from 1.2.0 → 1.2.1 and disable exporter service due to startup crash

## Test plan

- [ ] Verify evaluator guide renders correctly in docs site
- [ ] Confirm the API cert warning admonition appears in step 12.1
- [ ] Validate the slim `values-evaluator.yaml` overlay deploys cleanly against chart v1.2.1
- [ ] Check no previously-functional env vars are lost (MESSAGE_URL, RULE_ENRICHER_SERVER, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)