### PR TITLE
docs(self-hosted): clarify evaluator prereq wording for bundled-mode change

### DIFF
--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -166,7 +166,7 @@ kubectl create secret docker-registry gar-secret \
 
 ## 7. Install the five infrastructure prerequisites \{#self-hosted_local-evaluation-prereqs-install}
 
-The Plexicus chart 1.2.5+ does **not** bundle MongoDB / Redis / MinIO / PostgreSQL / Temporal — bundling them pushed the chart `.tgz` over the 1 MB Kubernetes Secret limit Helm uses for release storage. Install each as its own Helm release in the `plexicus` namespace.
+By default, the Plexicus chart does **not** deploy MongoDB / Redis / MinIO / PostgreSQL / Temporal — install each as its own Helm release in the `plexicus` namespace, then point the chart at them via `values-evaluator.yaml` in step 9.
 
 :::note Bitnami licensing change (August 2025)
 Bitnami moved their official chart images to a paid distribution. Free legacy images live under `docker.io/bitnamilegacy/*`. The commands below override every image reference (main + init + sidecar containers) accordingly. The `bitnamilegacy/*` images are amd64-only — perfect for this Ubuntu evaluator path.


### PR DESCRIPTION
## Summary
- One-line wording fix in step 7 of `local-evaluation.mdx`
- Removes the stale rationale (\"chart doesn't bundle because .tgz exceeds the 1 MB Helm Secret limit\") that becomes inaccurate once [plexicus/platform-charts#19](https://github.com/plexicus/platform-charts/pull/19) lands
- New wording (\"by default the chart does not deploy ... — install separately\") is correct both before and after #19 merges
- Five-prereq install procedure below is unchanged

## Context
PR plexicus/platform-charts#19 re-adds MongoDB / Redis / MinIO / PostgreSQL / Temporal as **opt-in** chart dependencies (`enabled: false` by default). Evaluators following this guide will continue to install them as separate Helm releases — no behavior change for them. But the doc sentence that says \"chart 1.2.4+ does not bundle\" becomes literally false once #19 ships, since the deps are bundled, just disabled. This PR rewrites that sentence to be timing-independent.

## Test plan
- [ ] Render the page locally (`pnpm start`) and confirm step 7 reads naturally
- [ ] Spot-check that the five-command install block immediately below is unaffected
- [ ] Land after plexicus/platform-charts#19 is merged (or before — wording works either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)