### PR TITLE
docs(self-hosted): bump install-target chart references to 1.2.6

### DIFF
--- a/docs/self-hosted/helm-chart.mdx
+++ b/docs/self-hosted/helm-chart.mdx
@@ -323,7 +323,7 @@ The default in-cluster service names produced by these installs are `mongodb`, `
 The remaining commands in this guide reference a `$CHART_VERSION` shell variable. Set it once to the version you want to install — your Plexicus contact will provide the current version when you receive registry credentials. To upgrade later, contact **[engineering@plexicus.ai](mailto:engineering@plexicus.ai)** for the latest version.
 
 ```bash
-export CHART_VERSION=1.2.5
+export CHART_VERSION=1.2.6
 ```
 
 This variable persists for the rest of your shell session.
@@ -803,7 +803,7 @@ The procedure below was validated end-to-end on `demo.plexicus.com` (k3s + ArgoC
 - **Prereq service names take the `<release-name>-` prefix.** When ArgoCD creates the Bitnami Helm releases as Applications named `plexicus-mongodb`, `plexicus-redis`, etc., the in-cluster Services are `plexicus-mongodb`, `plexicus-redis-master`, `plexicus-temporal-postgresql`, `plexicus-temporal-frontend`, etc. — not the bare `mongodb` / `redis-master` defaults. Update `global.required.database.host`, `global.required.minio.service`, `global.required.redis.host`, `global.dependencies.temporal.host`, and `global.dependencies.redis.host` in the umbrella Application's `helm.values` block to match. (Setting `fullnameOverride` on each prereq Application is an alternative if you prefer the bare names.)
 - **The AppProject's `sourceRepos` list must include every chart source you reference**, including the OCI registry that hosts the Plexicus chart. Either enumerate them explicitly or use `sourceRepos: ['*']` in development.
 - **Self-signed certificates on the chart's OCI registry break ArgoCD's repo-server pull** even when `insecure: "true"` is set on the repository Secret. Either expose the registry behind an Ingress with a publicly trusted (Let's Encrypt) certificate, OR mount your private CA into the `argocd-repo-server` pod's truststore. The first option is simpler — register a DNS record like `registry.<your-domain>` pointing at the cluster, add a cert-manager-issued LE certificate to the registry's Ingress, and use `https://registry.<your-domain>/charts` as the OCI URL.
-- **Image-tag drift between bundled Plexicus services and the published GAR images.** The chart pins `<service>.image.tag` to the chart version (e.g. `1.2.5`), but the actual GAR images use independent build numbers (`1.0.NNN`) with a `latest` floating tag. Either override `<service>.image.tag: latest` in the umbrella's `helm.values` (acceptable for evaluation), or pin specific build tags per service for reproducible production deployments.
+- **Image-tag drift between bundled Plexicus services and the published GAR images.** The chart pins `<service>.image.tag` to the chart version (e.g. `1.2.6`), but the actual GAR images use independent build numbers (`1.0.NNN`) with a `latest` floating tag. Either override `<service>.image.tag: latest` in the umbrella's `helm.values` (acceptable for evaluation), or pin specific build tags per service for reproducible production deployments.
 :::
 
 <Steps>
@@ -1034,7 +1034,7 @@ The procedure below was validated end-to-end on `demo.plexicus.com` (k3s + ArgoC
       source:
         repoURL: europe-west3-docker.pkg.dev/plexicus-registry/charts
         chart: plexicus
-        targetRevision: "1.2.5"
+        targetRevision: "1.2.6"
         helm:
           values: |
             global:

--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -476,7 +476,7 @@ cat /root/keys.json | helm registry login \
   --username _json_key \
   --password-stdin
 
-export CHART_VERSION=1.2.5   # ask engineering@plexicus.ai for the latest published version
+export CHART_VERSION=1.2.6   # ask engineering@plexicus.ai for the latest published version
 
 helm upgrade --install plexicus \
   oci://europe-west3-docker.pkg.dev/plexicus-registry/charts/plexicus \


### PR DESCRIPTION
## Summary
- Bumps `CHART_VERSION` examples and ArgoCD `targetRevision` from `1.2.5` to `1.2.6` (the version just released in platform-charts)
- Bumps the image-tag drift example from `1.2.5` to `1.2.6`
- Leaves "chart 1.2.5+" mentions untouched — those describe when a feature/fix was introduced (historical accuracy, not current-version statements)

## Files changed
- `docs/self-hosted/local-evaluation.mdx` — `export CHART_VERSION=1.2.6`
- `docs/self-hosted/helm-chart.mdx` — `export CHART_VERSION=1.2.6`, image-tag example, ArgoCD `targetRevision`

## Test plan
- [x] Diff inspected: only install-target references changed, 4 sites updated
- [ ] Visual smoke-check that the rendered docs page still flows after the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)