### PR TITLE
docs(self-hosted): document hostAliases for SSR fix in evaluator overlay

### DIFF
--- a/docs/self-hosted/local-evaluation.mdx
+++ b/docs/self-hosted/local-evaluation.mdx
@@ -436,6 +436,16 @@ fastapi:
 
 frontend:
   existingSecret: plexicus-frontend
+  # Nuxt SSR renders pages server-side and fetches https://api.plexicus.local/...
+  # from inside the pod. The cluster's DNS can't resolve `api.plexicus.local`
+  # (that name only exists in your laptop's /etc/hosts), so SSR fetches fail
+  # and pages render empty/broken. hostAliases adds /etc/hosts entries
+  # *inside the pod* so the SSR request resolves to your ingress LB.
+  # Replace <server-ip> with the EXTERNAL-IP shown by:
+  #   kubectl -n ingress-nginx get svc ingress-nginx-controller
+  hostAliases:
+    - ip: "<server-ip>"
+      hostnames: [api.plexicus.local]
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
## Summary
- Adds `frontend.hostAliases` block to the `values-evaluator.yaml` example in step 9 of the local-evaluation guide
- Explains why it's needed (Nuxt SSR cluster-internal fetch to `api.plexicus.local` fails without /etc/hosts injection)
- Uses `<server-ip>` placeholder so evaluators substitute their own ingress LB IP

## Why this matters
Every fresh evaluator install hits the same bug: pages render empty/broken because Nuxt SSR can't resolve `api.plexicus.local` from inside the cluster (it only exists in the evaluator's laptop `/etc/hosts`). The chart already supports `frontend.hostAliases` via `charts/frontend/templates/deployment.yaml` — this PR just documents the required value so evaluators don't have to diagnose the symptom themselves.

The same pattern is already in use on the Plexicus dev cluster (`argocd/environments/dev/application.yaml:299`).

## Test plan
- [x] YAML block renders cleanly in MDX (no syntax errors)
- [x] Validated on a fresh Hetzner evaluator install — frontend pod's `/etc/hosts` now contains the HostAliases entry and resolves `api.plexicus.local` to the ingress LB IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)